### PR TITLE
Basic_materials dependency removal

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -719,9 +719,9 @@ minetest.register_abm({
 minetest.register_craft({
     output = "new_campfire:grille",
 	recipe = {
-		{ "basic_materials:steel_bar", "",                           "basic_materials:steel_bar" },
-		{ "",                          "basic_materials:steel_wire", "" },
-		{ "basic_materials:steel_bar", "",                           "basic_materials:steel_bar" },
+		{ "default:iron_ingot", "",                           "default:iron_ingot" },
+		{ "",                          "xpanes:bar_flat", "" },
+		{ "default:iron_ingot", "",                           "default:iron_ingot" },
 	}
 })
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = new_campfire
 description = You can craft and use better campfire.
-depends = default, fire, basic_materials
+depends = default, fire
 optional_depends = campfire
 min_minetest_version = 5.2.0


### PR DESCRIPTION
Since not everyone has the basic_materials mod installed and do not want to install it, i've changed the crafting recipe of the grille to make it work even without basic_materials.
My suggestion is to keep the basic_materials one but in a different branch